### PR TITLE
fix: scope label takeover to role=status + aria-live=polite

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,12 @@ location.reload()
    该子路径会直接 `ERR_PACKAGE_PATH_NOT_EXPORTED`,导致插件加载失败。
 2. **改 `cordis.patch.yml` 不会热加载**:本机启动命令没带 `--expose-internals`,
    客户端 HMR 服务没起来,新增插件必须重启 `dsh web` 才生效。
-3. **不能用文本匹配找状态标签**:聊天记录里引用过 `Deep diving...` 的代码片段
-   会被渲染成 `<code>` 元素,按文本匹配会误伤它们;状态标签只按
-   `role="status"` 定位即可(页面上该角色唯一)。
+3. **不能用文本匹配找状态标签,`role="status"` 也不唯一**:聊天记录里引用过
+   `Deep diving...` 的代码片段会被渲染成 `<code>` 元素,按文本匹配会误伤
+   它们;而输入栏 notice、重试行、回合错误提示等 aria-live 区域同样带
+   `role="status"`,只按角色定位会把它们的真实状态文案也换掉。当前按
+   `role="status"` + `aria-live="polite"` 组合定位 TurnStatus(该组合在
+   页面上唯一)。
 4. **状态标签仅在回合运行时才存在**:刷新后 / 模型空闲时 `label=0` 是正常的,
    模型真正开始跑(首 token 前有网络与启动延迟)后才会变成 `1`。
 5. **浏览器翻译插件会改写文本**:Immersive Translate 会把 `Deep diving...`

--- a/lib/client.js
+++ b/lib/client.js
@@ -63,8 +63,6 @@ window.__ModuleLoader__.load({
 
 		/** 每隔多少毫秒换一句 */
 		const INTERVAL_MS = 10000;
-		/** 要替换的原始文案;若你改过 dsh-client-ui-conversation 里的原文,请同步修改 */
-		const ORIGINALS = ["Deep diving..."];
 		/** localStorage 覆盖键 */
 		const STORAGE_KEY = "dsh-status-rotator.texts";
 		/** 诊断日志开关:true 时在浏览器控制台输出 [status-rotator] 日志 */
@@ -93,9 +91,12 @@ window.__ModuleLoader__.load({
 
 		/**
 		 * 找到并接管对话流里的运行状态标签:
-		 * TurnStatus 渲染为一个 role="status" 的 div,第一个子节点是
-		 * 文案文本节点;运行 15 秒后第二个子节点会出现时钟 span。
-		 * 我们只替换文本节点,时钟不受影响。
+		 * TurnStatus 渲染为一个 role="status" + aria-live="polite" 的 div,
+		 * 第一个子节点是文案文本节点;运行 15 秒后第二个子节点会出现时钟
+		 * span。我们只替换文本节点,时钟不受影响。
+		 * 注意:页面上 role="status" 并不唯一(输入栏 notice、重试行、回合
+		 * 错误提示等 aria-live 区域也用它),必须叠加 aria-live="polite"
+		 * 才能精确定位 TurnStatus。
 		 */
 		function apply(ctx) {
 			const log = (...args) => {
@@ -133,11 +134,13 @@ window.__ModuleLoader__.load({
 
 			const adopt = (el) => {
 				if (adopted.has(el)) return;
-				// 只按 role="status" 接管(页面上该角色唯一,就是状态标签)。
-				// 不用文本匹配——否则会误伤聊天记录里引用 "Deep diving..." 的代码片段。
-				if (el.getAttribute("role") === "status") {
+				// 只接管 TurnStatus:role="status" + aria-live="polite" 的组合
+				// 在页面上唯一。不能只按 role="status" 匹配——输入栏 notice、
+				// 重试行、回合错误提示等 aria-live 区域也用它,会把它们的真实
+				// 状态文案一并换掉;也不能按文本匹配——聊天记录里引用
+				// "Deep diving..." 的代码片段会被误伤。
+				if (el.getAttribute("role") === "status" && el.getAttribute("aria-live") === "polite") {
 					adopted.add(el);
-					el.dataset.statusRotator = "adopted";
 					log("adopted, 当前文本:", JSON.stringify(el.textContent.slice(0, 40)));
 					applyText(el);
 				}
@@ -165,12 +168,12 @@ window.__ModuleLoader__.load({
 
 			const scan = (root) => {
 				if (!(root instanceof Element)) return;
-				for (const el of root.querySelectorAll('[role="status"]')) adopt(el);
+				for (const el of root.querySelectorAll('[role="status"][aria-live="polite"]')) adopt(el);
 			};
 
-			/** 兜底轮询:每 2 秒按 role=status 重扫一次 */
+			/** 兜底轮询:每 2 秒按 TurnStatus 选择器重扫一次 */
 			const rescanAll = () => {
-				const status = document.querySelectorAll('[role="status"]');
+				const status = document.querySelectorAll('[role="status"][aria-live="polite"]');
 				if (status.length !== lastSeenStatusCount) {
 					lastSeenStatusCount = status.length;
 					log("rescan: 状态标签 ×", status.length);
@@ -182,7 +185,7 @@ window.__ModuleLoader__.load({
 				for (const record of records) {
 					for (const node of record.addedNodes) {
 						if (node instanceof Element) {
-							// 文本匹配优先(不依赖 role),再扫嵌套的 role=status
+							// 新增节点本身可能是目标,也可能嵌套着目标
 							adopt(node);
 							scan(node);
 						}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name":  "dsh-status-rotator",
-    "version":  "0.1.2",
+    "version":  "0.1.3",
     "private":  true,
     "description":  "Rotates the DSH chat turn-status label (\"Deep diving...\") through user-defined phrases every few seconds.",
     "type":  "module",


### PR DESCRIPTION
## 问题

当前插件按 ole="status" 接管元素,但 dsh 新版界面里该角色并不唯一:输入栏 notice、重试行、回合错误提示等 aria-live 区域都带它,插件会把它们的真实状态文案一起替换掉。

## 修复

将接管条件收紧为 ole="status" + ria-live="polite" 组合(TurnStatus 独有,已对照 dsh-client-ui-conversation 源码确认该组合在页面上唯一),并清理未使用的 ORIGINALS 常量与过期注释,版本升至 0.1.3。

## 验证

- 已安装到本地 profile 并重启 dsh web,启动清单包含 dsh-status-rotator
- served bundle 已确认包含新选择器
- node --check 语法通过