### PR TITLE
chore: 声明 dsh.bundle manifest，支持 dsh plugin add 安装

### DIFF
--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -1,0 +1,6 @@
+# dsh-status-rotator bundle patch.
+# 与 README「安装」一节的手动步骤一致:把插件行插入所选 profile 的 cordis 配置。
+# 声明在 package.json 的 dsh.bundle.patch 中,使 `dsh plugin add` 可直接安装。
+- insert:
+    - id: status-rotator
+      name: dsh-status-rotator

--- a/package.json
+++ b/package.json
@@ -11,11 +11,14 @@
                     "./package.json":  "./package.json"
                 },
     "dsh":  {
+                "bundle":  {
+                               "patch":  "./cordis.patch.yml"
+                           },
                 "client":  {
                                "platform":  "web",
                                "inject":  [
 
-                                          ],
+                                           ],
                                "immediately":  true
                            }
             },

--- a/scripts/package-release.cjs
+++ b/scripts/package-release.cjs
@@ -18,6 +18,7 @@ const files = [
   "config.example.json",
   "gen-config.cjs",
   "package.json",
+  "cordis.patch.yml",
   "README.md",
   "CONTRIBUTORS.md",
   "LICENSE"


### PR DESCRIPTION
## 变更内容

为收录进 [awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) 插件精选列表做准备（该列表的[贡献指南](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/blob/main/contributing.md)要求仓库声明 `dsh.bundle` manifest，否则无法通过 `dsh plugin add` 安装、条目会被拒收）：

- `package.json` 新增 `dsh.bundle.patch`，指向 `./cordis.patch.yml`
- 新增根目录 `cordis.patch.yml`：内容与 README「安装」一节的手动步骤一致（`id: status-rotator`, `name: dsh-status-rotator`）
- `scripts/package-release.cjs` 发布清单加入 `cordis.patch.yml`

合并后即可通过 `dsh plugin add 01Virex/dsh-status-rotator` 一键安装。