### PR TITLE
feat(settings): 按 DSH 官方设置页风格重排设置窗口控件与排版

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1601,8 +1601,11 @@ window.__ModuleLoader__.load({
 			const SETTINGS_DICTS = {
 				zh: {
 					"nav.label": "状态文案",
-					"title": "状态文案词库",
+					"title": "状态文案",
+					"intro": "调整轮换节奏与实时显示,并编辑各阶段的提示文案。",
+					"library": "文案词库",
 					"basic": "基本设置",
+					"basicDesc": "轮换间隔、打字机速度与阶段判定等核心参数。",
 					"basic.fontWeight": "字体粗细",
 					"fontWeight.inherit": "跟随界面(默认)",
 					"fontWeight.invalid": "字重必须是 1~1000 的数字或 inherit",
@@ -1674,8 +1677,11 @@ window.__ModuleLoader__.load({
 				},
 				en: {
 					"nav.label": "Status Texts",
-					"title": "Status Phrase Library",
+					"title": "Status Texts",
+					"intro": "Tune rotation timing and live display, then edit the phrases shown per phase.",
+					"library": "Phrase library",
 					"basic": "Basic settings",
+					"basicDesc": "Rotation interval, typewriter speed, and phase thresholds.",
 					"basic.fontWeight": "Font weight",
 					"fontWeight.inherit": "Follow UI (default)",
 					"fontWeight.invalid": "Weight must be 1–1000 or \\\"inherit\\\"",
@@ -1788,35 +1794,80 @@ window.__ModuleLoader__.load({
 			const phraseLines = (list) => (Array.isArray(list) ? list.filter((s) => typeof s === "string").join("\n") : "");
 			const parseLines = (text) => String(text || "").split(/\r?\n/).map((s) => s.trim()).filter((s) => s.length > 0);
 
-			/** 设置页样式(纯 CSS,复用 DSH 主题变量,不依赖额外包) */
+			/** 设置页样式(纯 CSS,与官方设置页共用同一套 DSH 主题令牌与排版)
+			 *  结构参考官方 Models / Plugins / Agent Presets 设置页:
+			 *  section(720 列) → 页面标题/简介 → 分组卡片,内部用官方按钮/
+			 *  输入框/开关/下拉/药丸等视觉语言,全部走 --dsw-alias-* 令牌。 */
 			const SETTINGS_CSS =
-				".dsh-sr-settings{display:flex;flex-direction:column;gap:14px;width:100%;max-width:560px;color:var(--dsw-alias-label-primary,inherit)}" +
-				".dsh-sr-settings h3{margin:0;font-size:16px;font-weight:600}" +
-				".dsh-sr-head{display:flex;align-items:center;justify-content:space-between;gap:12px}" +
-				".dsh-sr-actions{display:flex;align-items:center;gap:8px}" +
-				".dsh-sr-save,.dsh-sr-tab{cursor:pointer;font:inherit;border-radius:999px;padding:6px 14px;border:1px solid var(--dsw-alias-label-primary-dimmed,rgba(127,127,127,.45));background:var(--dsw-alias-bg-layer-1,transparent);color:var(--dsw-alias-label-primary,inherit)}" +
-				".dsh-sr-save{background:var(--dsw-alias-label-primary,#111);color:var(--dsw-alias-label-primary-foreground,#fff)}" +
-				".dsh-sr-save:disabled,.dsh-sr-tab:disabled{opacity:.55;cursor:default}" +
-				".dsh-sr-tabs{display:flex;gap:8px}" +
-				".dsh-sr-tab.dsh-sr-active{background:var(--dsw-alias-label-primary,#111);color:var(--dsw-alias-label-primary-foreground,#fff)}" +
-				".dsh-sr-section{display:flex;flex-direction:column;gap:10px}" +
-				".dsh-sr-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:10px}" +
-				".dsh-sr-field{display:flex;flex-direction:column;gap:6px;min-width:0}" +
-				".dsh-sr-label{font-size:12px;color:var(--dsw-alias-label-primary-dimmed,var(--dsw-alias-label-primary,inherit))}" +
+				/* 根列:与官方设置页一致(Models 720 / Plugins 760),颜色默认继承 */
+				".dsh-sr-settings{display:flex;flex-direction:column;gap:12px;width:100%;max-width:720px;color:var(--dsw-alias-label-primary)}" +
+				/* 页面标题(官方 16/500 标题)与简介(次要三级文字) */
+				".dsh-sr-title{margin:0;font-size:16px;font-weight:500;line-height:24px}" +
+				".dsh-sr-intro{margin:0;color:var(--dsw-alias-label-tertiary);font-size:13px;line-height:1.5}" +
+				/* 分组:官方 row 分隔线风格(hairline 分隔,竖向堆叠) */
+				".dsh-sr-group{border-bottom:1px solid var(--dsw-alias-border-l2);flex-direction:column;gap:12px;padding:16px 0;display:flex}" +
+				".dsh-sr-group:last-child{border-bottom:none;padding-bottom:4px}" +
+				".dsh-sr-grouphead{display:flex;align-items:center;justify-content:space-between;gap:8px}" +
+				".dsh-sr-grouphead h3{margin:0;font-size:14px;font-weight:500;line-height:22px;color:var(--dsw-alias-label-primary)}" +
 				".dsh-sr-phasehead{display:flex;align-items:baseline;justify-content:space-between;gap:8px}" +
-				".dsh-sr-muted{font-size:12px;color:var(--dsw-alias-label-primary-dimmed,var(--dsw-alias-label-primary,inherit))}" +
-				".dsh-sr-input,.dsh-sr-textarea,.dsh-sr-select{width:100%;box-sizing:border-box;background:var(--dsw-alias-bg-layer-1,transparent);color:var(--dsw-alias-label-primary,inherit);border:1px solid var(--dsw-alias-label-primary-dimmed,rgba(127,127,127,.45));border-radius:10px;padding:8px 10px;font:inherit;line-height:1.5}" +
-				".dsh-sr-textarea{resize:vertical;min-height:110px}" +
-				".dsh-sr-chips{display:flex;gap:6px;flex-wrap:wrap}" +
-				".dsh-sr-chip{cursor:pointer;font:inherit;font-size:12px;border-radius:999px;padding:3px 10px;border:1px solid var(--dsw-alias-label-primary-dimmed,rgba(127,127,127,.45));background:var(--dsw-alias-bg-layer-1,transparent);color:var(--dsw-alias-label-primary,inherit)}" +
-				".dsh-sr-chip.dsh-sr-on{background:var(--dsw-alias-label-primary,#111);color:var(--dsw-alias-label-primary-foreground,#fff)}" +
-				".dsh-sr-srow{display:flex;align-items:center;gap:8px;flex-wrap:wrap;border:1px solid var(--dsw-alias-label-primary-dimmed,rgba(127,127,127,.45));border-radius:10px;padding:8px}" +
-				".dsh-sr-srow .dsh-sr-select{flex:0 1 160px}" +
-				".dsh-sr-srow .dsh-sr-input{width:auto;flex:0 1 96px}" +
-				".dsh-sr-status{font-size:12px}" +
-				".dsh-sr-error{color:var(--dsw-alias-state-error-primary,#e5484d)}" +
-				".dsh-sr-ok{color:#30a46c}" +
-				".dsh-sr-warning{font-size:12px;color:var(--dsw-alias-state-warning-primary,#b7791f)}" +
+				".dsh-sr-hint{color:var(--dsw-alias-label-tertiary);margin:0;font-size:12px;line-height:18px}" +
+				".dsh-sr-muted{font-size:12px;color:var(--dsw-alias-label-tertiary)}" +
+				".dsh-sr-switchline{display:flex;align-items:center;gap:8px}" +
+				/* 通用按钮:36px 胶囊,primary 用官方主按钮填充 */
+				".dsh-sr-btn{box-sizing:border-box;height:36px;font:inherit;cursor:pointer;border:1px solid var(--dsw-alias-border-l2);border-radius:18px;align-items:center;gap:4px;padding:0 14px;font-size:14px;line-height:22px;display:inline-flex;color:var(--dsw-alias-label-primary);background:transparent}" +
+				".dsh-sr-btn:hover:not(:disabled){background:var(--dsw-alias-interactive-bg-hover)}" +
+				".dsh-sr-btn:focus-visible{box-shadow:0 0 0 2px var(--dsw-alias-border-l3);outline:none}" +
+				".dsh-sr-btn:disabled{opacity:.4;cursor:default}" +
+				".dsh-sr-btn-primary{background:var(--dsw-alias-button-primary-fill);color:var(--dsw-alias-label-primary-foreground);border-color:transparent}" +
+				".dsh-sr-btn-primary:hover:not(:disabled){background:var(--dsw-alias-button-primary-hover)}" +
+				".dsh-sr-btn-danger{color:var(--dsw-alias-state-error-primary)}" +
+				".dsh-sr-btn-danger:hover:not(:disabled){background:var(--dsw-alias-interactive-bg-hover-danger)}" +
+				/* 紧凑小按钮(28px,用于行内操作) */
+				".dsh-sr-btn-sm{height:28px;border-radius:14px;padding:0 10px;font-size:12px;line-height:18px}" +
+				/* 双列字段网格:间隔与官方 settings 一致 */
+				".dsh-sr-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:10px}" +
+				".dsh-sr-grid .dsh-sr-field{min-width:0}" +
+				".dsh-sr-field{display:flex;flex-direction:column;gap:6px;min-width:0}" +
+				".dsh-sr-label{font-size:12px;color:var(--dsw-alias-label-secondary)}" +
+				/* 表单控件:输入框 h32 r8,官方 Input 风格;select 带右箭头 */
+				".dsh-sr-input,.dsh-sr-textarea,.dsh-sr-select{box-sizing:border-box;width:100%;border:1px solid var(--dsw-alias-border-l2);background:var(--dsw-alias-bg-layer-1);color:var(--dsw-alias-label-primary);border-radius:8px;padding:0 10px;font:inherit;font-size:14px;line-height:22px}" +
+				".dsh-sr-input,.dsh-sr-select{height:32px}" +
+				".dsh-sr-input:focus,.dsh-sr-textarea:focus,.dsh-sr-select:focus{border-color:var(--dsw-alias-brand-primary);outline:none}" +
+				".dsh-sr-input::placeholder,.dsh-sr-textarea::placeholder{color:var(--dsw-alias-label-dimmed)}" +
+				".dsh-sr-input:disabled,.dsh-sr-textarea:disabled,.dsh-sr-select:disabled{opacity:.6;cursor:default}" +
+				".dsh-sr-textarea{resize:vertical;min-height:96px;padding:8px 10px;line-height:1.5}" +
+				".dsh-sr-select{appearance:none;cursor:pointer;background-image:url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' fill='none'%3E%3Cpath d='M3 4.5L6 7.5L9 4.5' stroke='%2381858C' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E\");background-position:right 12px center;background-repeat:no-repeat;background-size:12px 12px;padding-right:32px}" +
+				/* 官方风格开关:36×20 轨道 + 16 圆点 */
+				".dsh-sr-toggle{box-sizing:border-box;background:var(--dsw-alias-border-l3);cursor:pointer;border:0;border-radius:10px;flex:none;width:36px;height:20px;padding:2px;position:relative}" +
+				".dsh-sr-toggle:disabled{cursor:default;opacity:.5}" +
+				".dsh-sr-toggle:focus-visible{outline:2px solid var(--dsw-alias-brand-primary);outline-offset:2px}" +
+				".dsh-sr-toggleOn{background:var(--dsw-alias-brand-primary)}" +
+				".dsh-sr-toggleThumb{background:var(--dsw-alias-label-primary-foreground);border-radius:50%;width:16px;height:16px;transition:transform .12s;display:block}" +
+				".dsh-sr-toggleOn .dsh-sr-toggleThumb{transform:translate(16px)}" +
+				/* 语言切换:官方底层 tab 风格(下划线指示条) */
+				".dsh-sr-tabs{border-bottom:1px solid var(--dsw-alias-border-l2);align-items:flex-end;gap:22px;display:flex}" +
+				".dsh-sr-tab{color:var(--dsw-alias-label-tertiary);font:inherit;cursor:pointer;background:none;border:0;padding:7px 1px 9px;font-size:13px;line-height:20px;position:relative}" +
+				".dsh-sr-tab:hover,.dsh-sr-tab.dsh-sr-active{color:var(--dsw-alias-label-primary)}" +
+				".dsh-sr-tab.dsh-sr-active:after{background:var(--dsw-alias-label-primary);content:\"\";border-radius:2px 2px 0 0;height:2px;position:absolute;bottom:-1px;left:0;right:0}" +
+				/* 星期药丸:官方 Pill 组件风格(24 高,active 用 ghost-active 填充+描边) */
+				".dsh-sr-chips{display:flex;gap:4px;flex-wrap:wrap}" +
+				".dsh-sr-btnrow{display:flex;align-items:center;gap:8px;flex-wrap:wrap}" +
+				".dsh-sr-chip{cursor:pointer;font:inherit;border:none;border-radius:12px;height:24px;align-items:center;padding:0 8px;font-size:12px;line-height:18px;display:inline-flex;color:var(--dsw-alias-label-secondary);background:var(--dsw-alias-bg-layer-2)}" +
+				".dsh-sr-chip:hover:not(:disabled){background:var(--dsw-alias-interactive-bg-hover)}" +
+				".dsh-sr-chip.dsh-sr-on{color:var(--dsw-alias-label-primary);background:var(--dsw-alias-button-ghost-active-fill);box-shadow:inset 0 0 0 1px var(--dsw-alias-button-ghost-active-border)}" +
+				".dsh-sr-chip:disabled{cursor:default;opacity:.5}" +
+				/* 时段调度行:官方 28px 紧凑控件 */
+				".dsh-sr-srow{display:flex;align-items:center;gap:8px;flex-wrap:wrap}" +
+				".dsh-sr-srow .dsh-sr-select{flex:0 1 170px}" +
+				".dsh-sr-srow .dsh-sr-input{width:auto;flex:0 1 100px}" +
+				/* 状态条与警示 */
+				".dsh-sr-status{font-size:12px;line-height:18px}" +
+				".dsh-sr-error{color:var(--dsw-alias-state-error-primary)}" +
+				".dsh-sr-ok{color:var(--dsw-alias-state-success-primary)}" +
+				".dsh-sr-warning{color:var(--dsw-alias-state-warn-label);font-size:12px;line-height:18px}" +
+				/* 底部提示:文案输入区下方的统一样式 */
+				".dsh-sr-foot{color:var(--dsw-alias-label-tertiary);font-size:12px;line-height:18px}" +
+				/* 实时状态 Pill(浮层,与设置页无关但样式同处注入) */
 				".dsh-sr-pill{position:fixed;z-index:2147483000;pointer-events:auto;font:inherit;font-size:12.5px;line-height:1.5;padding:6px 12px;border-radius:999px;background:var(--dsw-alias-bg-layer-2,rgba(20,23,29,.92));border:1px solid var(--dsw-alias-label-primary-dimmed,rgba(127,127,127,.45));color:var(--dsw-alias-label-primary,#d8dbe0);box-shadow:0 4px 16px rgba(0,0,0,.35);backdrop-filter:blur(6px);white-space:nowrap;max-width:70vw;overflow:hidden;text-overflow:ellipsis}" +
 				".dsh-sr-pill-right-bottom{right:16px;bottom:14px}" +
 				".dsh-sr-pill-left-bottom{left:16px;bottom:14px}" +
@@ -2116,25 +2167,44 @@ window.__ModuleLoader__.load({
 
 				const loc = editLang;
 				const d = drafts[loc] || {};
+				const locked = loading || saving;
 				const presetOptions = (selected, onChange) => react.createElement("select", {
 					className: "dsh-sr-select",
 					value: selected,
-					disabled: loading || saving,
+					disabled: locked,
 					onChange,
 				},
 					react.createElement("option", { value: "" }, t("preset.none")),
 					presets.map((p) => react.createElement("option", { key: p.id, value: p.id }, labelOf(p, editLang) || p.id))
 				);
+				/** 行内按钮(extraClass 追加 dsh-sr-btn-primary/-danger/-sm 等修饰) */
+				const textBtn = (label, onClick, extraClass) => react.createElement("button", {
+					type: "button",
+					className: "dsh-sr-btn" + (extraClass ? " " + extraClass : ""),
+					disabled: locked,
+					onClick,
+				}, label);
+				/** 官方风格开关按钮(role="switch",36×20 轨道) */
+				const toggle = (checked, onChange, label) => react.createElement("button", {
+					type: "button",
+					role: "switch",
+					"aria-checked": checked,
+					"aria-label": label,
+					className: "dsh-sr-toggle" + (checked ? " dsh-sr-toggleOn" : ""),
+					disabled: locked,
+					onClick: () => onChange(!checked),
+				}, react.createElement("span", { className: "dsh-sr-toggleThumb" }));
 				const basicField = (key, labelKey) => react.createElement("label", { key, className: "dsh-sr-field" },
 					react.createElement("span", { className: "dsh-sr-label" }, t(labelKey)),
 					react.createElement("input", {
 						className: "dsh-sr-input",
 						type: "number",
 						value: basic[key],
+						disabled: locked,
 						onChange: (event) => setBasic((prev) => ({ ...prev, [key]: event.target.value })),
 					})
 				);
-				/** 弹幕等数字字段的通用输入(绑定到任意 {key: string} 草稿对象) */
+				/** 数字字段通用输入(绑定任意 {key: string} 草稿对象) */
 				const numField = (state, setter, key, labelKey, min, step) => react.createElement("label", { key, className: "dsh-sr-field" },
 					react.createElement("span", { className: "dsh-sr-label" }, t(labelKey)),
 					react.createElement("input", {
@@ -2143,38 +2213,47 @@ window.__ModuleLoader__.load({
 						value: state[key],
 						min,
 						step,
-						disabled: loading || saving,
+						disabled: locked,
 						onChange: (event) => setter((prev) => ({ ...prev, [key]: event.target.value })),
 					})
 				);
 
 				return react.createElement("div", { className: "dsh-sr-settings" },
-					react.createElement("div", { className: "dsh-sr-head" },
-						react.createElement("h3", null, t("title")),
-						react.createElement("div", { className: "dsh-sr-actions" },
-							react.createElement("button", { type: "button", className: "dsh-sr-tab", disabled: loading || saving, onClick: load }, t("reload")),
-							react.createElement("button", { type: "button", className: "dsh-sr-save", disabled: loading || saving, onClick: save }, saving ? t("saving") : t("save"))
+					// 页面标题 + 说明(与官方设置页一致)
+					react.createElement("h2", { className: "dsh-sr-title" }, t("title")),
+					react.createElement("p", { className: "dsh-sr-intro" }, t("intro")),
+					// 工具栏:重读 + 保存(主按钮在右,同官方 header 动作区)
+					react.createElement("div", { className: "dsh-sr-grouphead" },
+						react.createElement("span", { "aria-hidden": "true" }),
+						react.createElement("div", { className: "dsh-sr-btnrow", style: { marginLeft: "auto" } },
+							textBtn(t("reload"), load),
+							textBtn(saving ? t("saving") : t("save"), save, "dsh-sr-btn-primary")
 						)
 					),
-					hasOverride ? react.createElement("div", { className: "dsh-sr-warning" }, t("overrideWarning")) : null,
-					loadError ? react.createElement("div", { className: "dsh-sr-error" }, t("loadError") + ": " + loadError) : null,
-					status.text ? react.createElement("div", { className: "dsh-sr-status " + (status.kind === "ok" ? "dsh-sr-ok" : "dsh-sr-error") }, status.text) : null,
-					react.createElement("div", { className: "dsh-sr-section" },
-						react.createElement("div", { className: "dsh-sr-phasehead" },
-							react.createElement("span", { className: "dsh-sr-label" }, t("preset")),
+					hasOverride ? react.createElement("p", { className: "dsh-sr-warning", role: "status" }, t("overrideWarning")) : null,
+					loadError ? react.createElement("p", { className: "dsh-sr-error", role: "alert" }, t("loadError") + ": " + loadError) : null,
+					status.text ? react.createElement("p", { className: "dsh-sr-status " + (status.kind === "ok" ? "dsh-sr-ok" : "dsh-sr-error"), role: "status" }, status.text) : null,
+					// 预设选择
+					react.createElement("section", { className: "dsh-sr-group" },
+						react.createElement("div", { className: "dsh-sr-grouphead" },
+							react.createElement("h3", null, t("preset")),
 							react.createElement("span", { className: "dsh-sr-muted" }, t("preset.current").replace("{name}", currentLabel))
 						),
-						react.createElement("div", { className: "dsh-sr-actions" },
+						react.createElement("div", { className: "dsh-sr-btnrow" },
 							presetOptions(sel, (event) => {
 								setSelBoth(event.target.value);
 								applyDoc(doc, event.target.value);
 							}),
-							react.createElement("button", { type: "button", className: "dsh-sr-tab", disabled: loading || saving, onClick: setCurrent }, t("preset.set"))
+							textBtn(t("preset.set"), setCurrent)
 						),
-						react.createElement("div", { className: "dsh-sr-muted" }, t("preset.hint"))
+						react.createElement("p", { className: "dsh-sr-hint" }, t("preset.hint"))
 					),
-					react.createElement("div", { className: "dsh-sr-section" },
-						react.createElement("div", { className: "dsh-sr-label" }, t("basic")),
+					// 基本设置
+					react.createElement("section", { className: "dsh-sr-group" },
+						react.createElement("div", { className: "dsh-sr-grouphead" },
+							react.createElement("h3", null, t("basic")),
+							react.createElement("span", { className: "dsh-sr-muted" }, t("basicDesc"))
+						),
 						react.createElement("div", { className: "dsh-sr-grid" },
 							basicField("intervalMs", "intervalMs"),
 							basicField("typeSpeedMs", "typeSpeedMs"),
@@ -2184,9 +2263,9 @@ window.__ModuleLoader__.load({
 							react.createElement("label", { key: "fontWeight", className: "dsh-sr-field" },
 								react.createElement("span", { className: "dsh-sr-label" }, t("basic.fontWeight")),
 								react.createElement("select", {
-									className: "dsh-sr-input",
+									className: "dsh-sr-select",
 									value: basic.fontWeight,
-									disabled: loading || saving,
+									disabled: locked,
 									onChange: (event) => setBasic((prev) => ({ ...prev, fontWeight: event.target.value })),
 								},
 									["inherit", "100", "200", "300", "400", "500", "600", "700", "800", "900"].map((v) =>
@@ -2196,18 +2275,11 @@ window.__ModuleLoader__.load({
 							)
 						)
 					),
-					react.createElement("div", { className: "dsh-sr-section" },
-						react.createElement("div", { className: "dsh-sr-phasehead" },
-							react.createElement("span", { className: "dsh-sr-label" }, t("pill")),
-							react.createElement("label", { className: "dsh-sr-muted", style: { display: "flex", alignItems: "center", gap: 6 } },
-								react.createElement("input", {
-									type: "checkbox",
-									checked: pillDraft.enabled,
-									disabled: loading || saving,
-									onChange: (event) => setPillDraft((prev) => ({ ...prev, enabled: event.target.checked })),
-								}),
-								react.createElement("span", null, t("pill.enabled"))
-							)
+					// 实时状态 Pill
+					react.createElement("section", { className: "dsh-sr-group" },
+						react.createElement("div", { className: "dsh-sr-grouphead" },
+							react.createElement("h3", null, t("pill")),
+							toggle(pillDraft.enabled, (next) => setPillDraft((prev) => ({ ...prev, enabled: next })), t("pill.enabled"))
 						),
 						react.createElement("label", { className: "dsh-sr-field" },
 							react.createElement("span", { className: "dsh-sr-label" }, t("pill.template")),
@@ -2216,7 +2288,7 @@ window.__ModuleLoader__.load({
 								type: "text",
 								value: pillDraft.template,
 								spellCheck: false,
-								disabled: loading || saving,
+								disabled: locked,
 								onChange: (event) => setPillDraft((prev) => ({ ...prev, template: event.target.value })),
 							})
 						),
@@ -2225,25 +2297,18 @@ window.__ModuleLoader__.load({
 							react.createElement("select", {
 								className: "dsh-sr-select",
 								value: pillDraft.position,
-								disabled: loading || saving,
+								disabled: locked,
 								onChange: (event) => setPillDraft((prev) => ({ ...prev, position: event.target.value })),
 							},
 								["right-bottom", "left-bottom", "right-top", "left-top"].map((pos) => react.createElement("option", { key: pos, value: pos }, t("pill.pos." + pos)))
 							)
 						)
 					),
-					react.createElement("div", { className: "dsh-sr-section" },
-						react.createElement("div", { className: "dsh-sr-phasehead" },
-							react.createElement("span", { className: "dsh-sr-label" }, t("gradient")),
-							react.createElement("label", { className: "dsh-sr-muted", style: { display: "flex", alignItems: "center", gap: 6 } },
-								react.createElement("input", {
-									type: "checkbox",
-									checked: gradientDraft.enabled,
-									disabled: loading || saving,
-									onChange: (event) => setGradientDraft((prev) => ({ ...prev, enabled: event.target.checked })),
-								}),
-								react.createElement("span", null, t("gradient.enabled"))
-							)
+					// 炫彩渐变
+					react.createElement("section", { className: "dsh-sr-group" },
+						react.createElement("div", { className: "dsh-sr-grouphead" },
+							react.createElement("h3", null, t("gradient")),
+							toggle(gradientDraft.enabled, (next) => setGradientDraft((prev) => ({ ...prev, enabled: next })), t("gradient.enabled"))
 						),
 						react.createElement("div", { className: "dsh-sr-grid" },
 							react.createElement("label", { className: "dsh-sr-field" },
@@ -2253,7 +2318,7 @@ window.__ModuleLoader__.load({
 									type: "text",
 									value: gradientDraft.colors,
 									spellCheck: false,
-									disabled: loading || saving,
+									disabled: locked,
 									onChange: (event) => setGradientDraft((prev) => ({ ...prev, colors: event.target.value })),
 								})
 							),
@@ -2265,24 +2330,17 @@ window.__ModuleLoader__.load({
 									value: gradientDraft.speed,
 									min: "0.5",
 									step: "0.5",
-									disabled: loading || saving,
+									disabled: locked,
 									onChange: (event) => setGradientDraft((prev) => ({ ...prev, speed: event.target.value })),
 								})
 							)
 						)
 					),
-					react.createElement("div", { className: "dsh-sr-section" },
-						react.createElement("div", { className: "dsh-sr-phasehead" },
-							react.createElement("span", { className: "dsh-sr-label" }, t("danmaku")),
-							react.createElement("label", { className: "dsh-sr-muted", style: { display: "flex", alignItems: "center", gap: 6 } },
-								react.createElement("input", {
-									type: "checkbox",
-									checked: danmakuDraft.enabled,
-									disabled: loading || saving,
-									onChange: (event) => setDanmakuDraft((prev) => ({ ...prev, enabled: event.target.checked })),
-								}),
-								react.createElement("span", null, t("danmaku.enabled"))
-							)
+					// 弹幕
+					react.createElement("section", { className: "dsh-sr-group" },
+						react.createElement("div", { className: "dsh-sr-grouphead" },
+							react.createElement("h3", null, t("danmaku")),
+							toggle(danmakuDraft.enabled, (next) => setDanmakuDraft((prev) => ({ ...prev, enabled: next })), t("danmaku.enabled"))
 						),
 						react.createElement("div", { className: "dsh-sr-grid" },
 							numField(danmakuDraft, setDanmakuDraft, "intervalMs", "danmaku.intervalMs", "100"),
@@ -2301,7 +2359,7 @@ window.__ModuleLoader__.load({
 									type: "text",
 									value: danmakuDraft.colors,
 									spellCheck: false,
-									disabled: loading || saving,
+									disabled: locked,
 									onChange: (event) => setDanmakuDraft((prev) => ({ ...prev, colors: event.target.value })),
 								})
 							),
@@ -2310,33 +2368,24 @@ window.__ModuleLoader__.load({
 								react.createElement("select", {
 									className: "dsh-sr-select",
 									value: danmakuDraft.scope,
-									disabled: loading || saving,
+									disabled: locked,
 									onChange: (event) => setDanmakuDraft((prev) => ({ ...prev, scope: event.target.value })),
 								},
 									["all", "phase"].map((s) => react.createElement("option", { key: s, value: s }, t("danmaku.scope." + s)))
 								)
 							)
 						),
-						react.createElement("label", { className: "dsh-sr-muted", style: { display: "flex", alignItems: "center", gap: 6 } },
-							react.createElement("input", {
-								type: "checkbox",
-								checked: danmakuDraft.rainbow,
-								disabled: loading || saving,
-								onChange: (event) => setDanmakuDraft((prev) => ({ ...prev, rainbow: event.target.checked })),
-							}),
-							react.createElement("span", null, t("danmaku.rainbow"))
+						react.createElement("div", { className: "dsh-sr-switchline" },
+							toggle(danmakuDraft.rainbow, (next) => setDanmakuDraft((prev) => ({ ...prev, rainbow: next })), t("danmaku.rainbow")),
+							react.createElement("span", { className: "dsh-sr-label" }, t("danmaku.rainbow"))
 						),
-						react.createElement("div", { className: "dsh-sr-muted" }, t("danmaku.hint"))
+						react.createElement("p", { className: "dsh-sr-hint" }, t("danmaku.hint"))
 					),
-					react.createElement("div", { className: "dsh-sr-section" },
-						react.createElement("div", { className: "dsh-sr-phasehead" },
-							react.createElement("span", { className: "dsh-sr-label" }, t("schedule")),
-							react.createElement("button", {
-								type: "button",
-								className: "dsh-sr-tab",
-								disabled: loading || saving,
-								onClick: () => setScheduleDrafts((prev) => [...prev, { preset: presets.length > 0 ? presets[0].id : "", days: SCHEDULE_DAYS.slice(), from: "09:00", to: "18:00" }]),
-							}, t("schedule.add"))
+					// 时段调度
+					react.createElement("section", { className: "dsh-sr-group" },
+						react.createElement("div", { className: "dsh-sr-grouphead" },
+							react.createElement("h3", null, t("schedule")),
+							textBtn(t("schedule.add"), () => setScheduleDrafts((prev) => [...prev, { preset: presets.length > 0 ? presets[0].id : "", days: SCHEDULE_DAYS.slice(), from: "09:00", to: "18:00" }]))
 						),
 						scheduleDrafts.map((row, idx) => react.createElement("div", { key: idx, className: "dsh-sr-srow" },
 							presetOptions(row.preset, (event) => updateRow(idx, { preset: event.target.value })),
@@ -2345,42 +2394,43 @@ window.__ModuleLoader__.load({
 									key: day,
 									type: "button",
 									className: "dsh-sr-chip" + (row.days.includes(day) ? " dsh-sr-on" : ""),
-									disabled: loading || saving,
+									disabled: locked,
 									onClick: () => updateRow(idx, { days: row.days.includes(day) ? row.days.filter((x) => x !== day) : [...row.days, day] }),
 								}, t("day." + day)))
 							),
-							react.createElement("input", { className: "dsh-sr-input", type: "time", value: row.from, disabled: loading || saving, onChange: (event) => updateRow(idx, { from: event.target.value }) }),
-							react.createElement("input", { className: "dsh-sr-input", type: "time", value: row.to, disabled: loading || saving, onChange: (event) => updateRow(idx, { to: event.target.value }) }),
-							react.createElement("button", {
-								type: "button",
-								className: "dsh-sr-tab",
-								disabled: loading || saving,
-								onClick: () => setScheduleDrafts((prev) => prev.filter((_, i) => i !== idx)),
-							}, t("schedule.remove"))
+							react.createElement("input", { className: "dsh-sr-input", type: "time", value: row.from, disabled: locked, onChange: (event) => updateRow(idx, { from: event.target.value }) }),
+							react.createElement("input", { className: "dsh-sr-input", type: "time", value: row.to, disabled: locked, onChange: (event) => updateRow(idx, { to: event.target.value }) }),
+							textBtn(t("schedule.remove"), () => setScheduleDrafts((prev) => prev.filter((_, i) => i !== idx)), "dsh-sr-btn-danger")
 						)),
-						react.createElement("div", { className: "dsh-sr-muted" }, t("schedule.hint"))
+						react.createElement("p", { className: "dsh-sr-hint" }, t("schedule.hint"))
 					),
-					react.createElement("div", { className: "dsh-sr-tabs" },
-						SETTINGS_LOCALES.map((code) => react.createElement("button", {
-							key: code,
-							type: "button",
-							className: "dsh-sr-tab" + (lang === code ? " dsh-sr-active" : ""),
-							onClick: () => setLang(code),
-						}, t("language." + code)))
-					),
-					SETTINGS_PHASES.map((phase) => react.createElement("div", { key: phase, className: "dsh-sr-field" },
-						react.createElement("div", { className: "dsh-sr-phasehead" },
-							react.createElement("span", { className: "dsh-sr-label" }, t("phase." + phase)),
-							react.createElement("span", { className: "dsh-sr-muted" }, t("count").replace("{n}", String(parseLines(d[phase]).length)))
+					// 文案词库:语言切换 + 每阶段一个 textarea
+					react.createElement("section", { className: "dsh-sr-group" },
+						react.createElement("div", { className: "dsh-sr-grouphead" },
+							react.createElement("h3", null, t("library"))
 						),
-						react.createElement("textarea", {
-							className: "dsh-sr-textarea",
-							value: d[phase] || "",
-							spellCheck: false,
-							onChange: (event) => setDrafts((prev) => ({ ...prev, [loc]: { ...prev[loc], [phase]: event.target.value } })),
-						})
-					)),
-					react.createElement("div", { className: "dsh-sr-muted" }, t("hint"))
+						react.createElement("div", { className: "dsh-sr-tabs" },
+							SETTINGS_LOCALES.map((code) => react.createElement("button", {
+								key: code,
+								type: "button",
+								className: "dsh-sr-tab" + (lang === code ? " dsh-sr-active" : ""),
+								onClick: () => setLang(code),
+							}, t("language." + code)))
+						),
+						SETTINGS_PHASES.map((phase) => react.createElement("div", { key: phase, className: "dsh-sr-field" },
+							react.createElement("div", { className: "dsh-sr-grouphead" },
+								react.createElement("span", { className: "dsh-sr-label" }, t("phase." + phase)),
+								react.createElement("span", { className: "dsh-sr-muted" }, t("count").replace("{n}", String(parseLines(d[phase]).length)))
+							),
+							react.createElement("textarea", {
+								className: "dsh-sr-textarea",
+								value: d[phase] || "",
+								spellCheck: false,
+								onChange: (event) => setDrafts((prev) => ({ ...prev, [loc]: { ...prev[loc], [phase]: event.target.value } })),
+							})
+						)),
+						react.createElement("p", { className: "dsh-sr-foot" }, t("hint"))
+					)
 				);
 			};
 


### PR DESCRIPTION
### 概述

将设置窗口的整体视觉与排版重构为 **DSH 官方设置页(Models / Plugins / Agent Presets)风格**,统一复用官方 `--dsw-alias-*` 主题令牌,不再依赖自定义近似色。

### 变更内容

**页面骨架**
- 内容列宽由 560px 提升至官方 720px,自上而下为页面标题 + 简介 + 分组(hairline 分隔)。

**视觉控件**
- 设置分组改为官方 `Group + GroupHead + hint` 结构,并补充中英文标题/说明文案。
- 复选框全部替换为官方 36×20 开关(`role="switch"`,品牌色激活态)。
- 按钮统一为官方 36px 胶囊(primary/ghost/danger,另含 28px 紧凑小按钮变体)。
- 输入框 / 文本域 / 下拉统一为官方 Input 视觉(h32 / r8 / 聚焦品牌描边),select 增加自带箭头。
- 语言切换改为官方底部 tab(下划线指示条)风格;星期选择改为官方 Pill 药丸风格。
- 词库编辑与时段调度收纳进分组,补齐标题/说明文案。

**细节与健壮性**
- 所有控件在加载/保存期间统一进入 `disabled`(原部分控件遗漏,如数字字段、字体粗细下拉)。
- 校验/状态/错误提示改用语义化 `role="status"` / `role="alert"` 并补充可访问性标签。

仅改动 `lib/client.js`(设置页 CSS 与 JSX 结构),未涉及任何配置结构、存储键或后端行为,纯视觉重构、无功能变更。

### 截图

(可选,维护者可在本地 `dsh plugin add` 后查看)

### 检查清单

- [x] 改动范围与提交信息一致,无额外文件混入
- [x] 配置键/读写路径未变,旧配置完全兼容
- [x] 设置窗口在 zh/en 语言下均可用