### PR TITLE
feat: 加权随机文案选择(weighted random phrase picking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ dsh plugin --profile web add dsh-status-rotator
 
 > ⭐ **If this made you smile, give it a star** — it keeps the memes flowing.
 
-Replaces the `Deep diving...` status line in the DeepSeek Harness (dsh) Web UI's turn footer with your own text: phase-aware switching, typewriter output, animated rainbow gradient (optional), timed rotation, **template placeholders with live values** (`{elapsed}`, `{phase}`, `{model}`, `{tps}`…), optional **browser tab title** rotation, **a live status pill** (model, phase, elapsed, tokens/s — fed by the same real-time engine), **Danmaku** (your phrases float across the page behind the UI like bullet-screen comments on video sites), and **presets with time-of-day scheduling**. The elapsed-time clock (which appears after 15 seconds) is untouched.
+Replaces the `Deep diving...` status line in the DeepSeek Harness (dsh) Web UI's turn footer with your own text: phase-aware switching, typewriter output, animated rainbow gradient (optional), timed rotation, **weighted random picking** (raise or lower a phrase's chance), **template placeholders with live values** (`{elapsed}`, `{phase}`, `{model}`, `{tps}`…), optional **browser tab title** rotation, **a live status pill** (model, phase, elapsed, tokens/s — fed by the same real-time engine), **Danmaku** (your phrases float across the page behind the UI like bullet-screen comments on video sites), and **presets with time-of-day scheduling**. The elapsed-time clock (which appears after 15 seconds) is untouched.
 
 ## Installation
 
@@ -48,6 +48,7 @@ The plugin's `package.json` declares a `dsh.bundle.patch` manifest, so it's reco
 ## Features
 
 - **Phase-aware**: three sets of phrases — `thinking` (just started) / `running` (after 15s) / `long` (past the threshold). Switches immediately when the clock appears or the timeout hits, no need to wait for the rotation interval;
+- **Weighted random**: any phrase can carry a weight — pick order follows the weights instead of uniform randomness, so favorite phrases appear more often. In the settings editor write `text | weight` (e.g. `正在写代码 | 3`); in JSON use `{ "text": "...", "weight": 3 }`. Can be turned off with one switch (`weightedRandom: false`). Weights apply to the status line and the danmaku pool;
 - **Typewriter effect**: phrases are typed out character by character, speed configurable, 0 disables it;
 - **Template placeholders**: `{elapsed}` (live, refreshed every `liveTickMs`), `{phase}`, `{phaseLabel}`, `{locale}`, `{date}`, `{time}`, plus live-engine values `{model}`, `{provider}`, `{tps}`, `{pending}`, `{tools}`, `{running}` — e.g. `正在写代码 {elapsed}` shows a ticking clock inside the phrase;
 - **Real-time status engine**: subscribes to the dsh session snapshot (session list, conversation snapshot, model RPC, DOM clock fallback) — one source feeding the phrases, the tab title and the pill;
@@ -74,6 +75,22 @@ Phrases are split into three groups based on turn progress (determined by whethe
 | `long` | Clock past `longAfterMs` | ≥ 60s |
 
 Phase changes swap the phrase immediately without waiting for the rotation interval. If a phase has no phrase group, it falls back automatically (running → thinking → any non-empty group).
+
+## Weighted Random
+
+By default the wording is picked uniformly (avoiding immediate repeats). Give phrases a weight and the picker becomes proportional: a `weight: 3` phrase is 3× more likely than a `weight: 1` phrase.
+
+```json
+"phrases": { "zh": { "thinking": [
+    "正在写代码…",                    // plain string, weight 1
+    { "text": "正在加水…", "weight": 3 }   // 3× more likely
+] } }
+```
+
+- A phrase entry is a plain string (weight 1) or an object `{ "text": "...", "weight": 3 }`; `weight` must be a positive number (decimals allowed), values above 1000 clamp to 1000, invalid/missing weights count as 1. Weight entries are fully optional — old string-only phrase banks work unchanged.
+- In the **settings editor** write `text | weight` per line: `正在写代码 | 3`. The editor re-renders weighted phrases with their ` | weight` suffix on load; the `weightedRandom` toggle in Basic settings switches back to uniform picking without touching the phrase bank.
+- Weights apply to the status text rotation **and** the danmaku pool (danmaku dedupes by text, keeping the first entry's weight).
+- The "avoid repeating the previous phrase" rule stays: the last phrase is temporarily excluded from the draw (if it's the only candidate left, it repeats).
 
 ## Rainbow Gradient
 
@@ -208,7 +225,7 @@ Phrases are fully separated from the source code and live in JSON config files. 
 
 ```json
 {
-    "config": { "intervalMs": 10000, "typeSpeedMs": 30, "longAfterMs": 60000, "reloadIntervalMs": 15000, "liveTickMs": 1000, "debug": false, "gradient": { "enabled": true, "colors": ["#ff5f6d", "#ffc371", "#ffdd55", "#7dff7d", "#5fd4ff", "#a78bfa", "#ff8adb"], "speed": 4 }, "title": { "enabled": false, "templates": ["⏳ {phaseLabel} {elapsed}"], "idleTemplate": "", "intervalMs": 8000 }, "pill": { "enabled": true, "template": "{model} · {phaseLabel} · {elapsed} · ⚡{tps} tok/s", "position": "right-bottom", "opacity": 0.92 }, "danmaku": { "enabled": true, "intervalMs": 2500, "speedMs": 18000, "fontSizeMin": 14, "fontSizeMax": 30, "rainbow": true, "colors": ["#ff5f6d", "#ffc371", "#ffdd55", "#7dff7d", "#5fd4ff", "#a78bfa", "#ff8adb"], "color": "#ffffff", "opacity": 0.3, "maxCount": 12, "zIndex": -1, "scope": "all", "marginTop": 16, "marginBottom": 160 } },
+    "config": { "intervalMs": 10000, "typeSpeedMs": 30, "longAfterMs": 60000, "reloadIntervalMs": 15000, "liveTickMs": 1000, "weightedRandom": true, "debug": false, "gradient": { "enabled": true, "colors": ["#ff5f6d", "#ffc371", "#ffdd55", "#7dff7d", "#5fd4ff", "#a78bfa", "#ff8adb"], "speed": 4 }, "title": { "enabled": false, "templates": ["⏳ {phaseLabel} {elapsed}"], "idleTemplate": "", "intervalMs": 8000 }, "pill": { "enabled": true, "template": "{model} · {phaseLabel} · {elapsed} · ⚡{tps} tok/s", "position": "right-bottom", "opacity": 0.92 }, "danmaku": { "enabled": true, "intervalMs": 2500, "speedMs": 18000, "fontSizeMin": 14, "fontSizeMax": 30, "rainbow": true, "colors": ["#ff5f6d", "#ffc371", "#ffdd55", "#7dff7d", "#5fd4ff", "#a78bfa", "#ff8adb"], "color": "#ffffff", "opacity": 0.3, "maxCount": 12, "zIndex": -1, "scope": "all", "marginTop": 16, "marginBottom": 160 } },
     "phrases": { "zh": { "thinking": ["…"], "running": ["…"], "long": ["…"] }, "en": { "thinking": ["…"], "running": ["…"], "long": ["…"] } },
     "presets": [],          // optional, see "Presets & Scheduling"
     "activePreset": null,   // optional preset id
@@ -223,6 +240,7 @@ Phrases are fully separated from the source code and live in JSON config files. 
 | `longAfterMs` | 60000 | Threshold for entering the `long` phase |
 | `reloadIntervalMs` | 15000 | Interval for auto re-reading `config.json` while the page is open (ms), 0 disables |
 | `liveTickMs` | 1000 | Refresh interval for live placeholders (`{elapsed}` / `{date}` / `{time}` / `{tps}`…) in phrases, titles and the pill (ms), 0 disables |
+| `weightedRandom` | true | Weighted random picking. `false` = fully uniform over phrases. Phrase entries may be `"text"` or `{ "text": "...", "weight": 3 }` (weight > 0, capped at 1000, invalid/missing = 1) |
 | `debug` | false | Console diagnostic logs |
 | `fontWeight` | `"inherit"` | Font weight of the status text, the live pill and the danmaku: a number (1–1000; typical 100–900) or a CSS keyword (`normal`/`bold`/`bolder`/`lighter`); `"inherit"` follows the UI (default; danmaku keeps its built-in 600) |
 | `gradient` | see above | Rainbow gradient: `false` / `true` / `{enabled, colors, speed}` |
@@ -251,9 +269,9 @@ Phrases switch live between Chinese and English following Settings → Language;
 
 Open Settings in the bottom-left of DSH and a new **Status Texts** page appears in the navigation:
 
-- **中文 / English** tabs, each with three text boxes for `thinking` / `running` / `long`, **one phrase per line**, blank lines are ignored;
+- **中文 / English** tabs, each with three text boxes for `thinking` / `running` / `long`, **one phrase per line**, blank lines are ignored; a line `text | weight` sets that phrase's weight;
 - Each phase shows the current phrase count in real time;
-- Basic settings (rotation interval, typewriter speed, long-task threshold, auto-reload interval, placeholder refresh interval, font weight) live on the same page;
+- Basic settings (rotation interval, typewriter speed, long-task threshold, auto-reload interval, placeholder refresh interval, font weight, weighted-random toggle) live on the same page;
 - **Live pill settings**: enable toggle, display template, position — the pill and the live-engine placeholders are configured in the same page;
 - **Rainbow gradient settings**: enable toggle, color sequence, speed — no more manual `config.json` editing to turn the gradient off;
 - **Danmaku settings**: enable toggle, spawn interval, cross duration, random font-size range, rainbow mode + palette, opacity, max concurrent bullets, layer z-index and phrase scope — everything editable without touching `config.json`;

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -48,6 +48,7 @@ dsh plugin --profile web add dsh-status-rotator
 ## 特性
 
 - **阶段感知**:`thinking`(刚启动)/ `running`(15s 后)/ `long`(超过阈值)三组文案,时钟出现或超时立即切换,不用等轮换间隔;
+- **加权随机**:任意文案都可带权重,按权重比例抽取而非完全均匀——喜欢的文案出现更频繁。设置页里写 `文案 | 权重`(如 `正在写代码 | 3`),JSON 里写 `{ "text": "...", "weight": 3 }`;可一键关闭(`weightedRandom: false`)。权重同样作用于状态文字与弹幕池;
 - **打字机效果**:文案逐字"打"出,速度可调,设 0 即关闭;
 - **模板占位符**:`{elapsed}`(实时,按 `liveTickMs` 刷新)、`{phase}`、`{phaseLabel}`、`{locale}`、`{date}`、`{time}`,以及实时引擎字段 `{model}`、`{provider}`、`{tps}`、`{pending}`、`{tools}`、`{running}`,例如 `正在写代码 {elapsed}` 能让文案里出现走动的时长;
 - **实时状态引擎**:订阅 dsh 会话快照(会话列表/对话快照/模型 RPC/DOM 时钟兜底),文案、标题与 Pill 共用同一数据源;
@@ -74,6 +75,22 @@ dsh plugin --profile web add dsh-status-rotator
 | `long` | 时钟超过 `longAfterMs` | ≥ 60s |
 
 阶段切换会立即触发换文案,无需等轮换间隔。某阶段缺文案组时自动回退(running → thinking → 任意非空组)。
+
+## 加权随机
+
+默认按均匀随机抽取(避免连续重复)。给文案配上权重后,抽取变为按比例:权重 `3` 的文案出现概率是权重 `1` 的 3 倍。
+
+```json
+"phrases": { "zh": { "thinking": [
+    "正在写代码…",                       // 纯字符串,权重 1
+    { "text": "正在加水…", "weight": 3 }   // 3 倍概率
+] } }
+```
+
+- 一条文案可以是纯字符串(权重 1)或对象 `{ "text": "...", "weight": 3 }`;`weight` 须为正数(支持小数),超过 1000 按 1000 计,非法/缺省按 1 计。权重完全可选——旧的纯字符串词库零改动兼容;
+- **设置页编辑器**里每行写 `文案 | 权重`(如 `正在写代码 | 3`)即可;编辑器回写时会给加权文案追加 ` | 权重` 后缀。「基本设置」里的「加权随机」开关可一键回到完全均匀,不用改词库;
+- 权重同时作用于状态文字轮换与**弹幕池**(弹幕按文本去重,保留首条权重);
+- 「避免与上一句重复」规则保留:上一句在抽取时临时排除(若只剩它一个候选则重复)。
 
 ## 炫彩渐变
 
@@ -208,7 +225,7 @@ dsh plugin --profile web add dsh-status-rotator
 
 ```json
 {
-    "config": { "intervalMs": 10000, "typeSpeedMs": 30, "longAfterMs": 60000, "reloadIntervalMs": 15000, "liveTickMs": 1000, "debug": false, "gradient": { "enabled": true, "colors": ["#ff5f6d", "#ffc371", "#ffdd55", "#7dff7d", "#5fd4ff", "#a78bfa", "#ff8adb"], "speed": 4 }, "title": { "enabled": false, "templates": ["⏳ {phaseLabel} {elapsed}"], "idleTemplate": "", "intervalMs": 8000 }, "pill": { "enabled": true, "template": "{model} · {phaseLabel} · {elapsed} · ⚡{tps} tok/s", "position": "right-bottom", "opacity": 0.92 }, "danmaku": { "enabled": true, "intervalMs": 2500, "speedMs": 18000, "fontSizeMin": 14, "fontSizeMax": 30, "rainbow": true, "colors": ["#ff5f6d", "#ffc371", "#ffdd55", "#7dff7d", "#5fd4ff", "#a78bfa", "#ff8adb"], "color": "#ffffff", "opacity": 0.3, "maxCount": 12, "zIndex": -1, "scope": "all", "marginTop": 16, "marginBottom": 160 } },
+    "config": { "intervalMs": 10000, "typeSpeedMs": 30, "longAfterMs": 60000, "reloadIntervalMs": 15000, "liveTickMs": 1000, "weightedRandom": true, "debug": false, "gradient": { "enabled": true, "colors": ["#ff5f6d", "#ffc371", "#ffdd55", "#7dff7d", "#5fd4ff", "#a78bfa", "#ff8adb"], "speed": 4 }, "title": { "enabled": false, "templates": ["⏳ {phaseLabel} {elapsed}"], "idleTemplate": "", "intervalMs": 8000 }, "pill": { "enabled": true, "template": "{model} · {phaseLabel} · {elapsed} · ⚡{tps} tok/s", "position": "right-bottom", "opacity": 0.92 }, "danmaku": { "enabled": true, "intervalMs": 2500, "speedMs": 18000, "fontSizeMin": 14, "fontSizeMax": 30, "rainbow": true, "colors": ["#ff5f6d", "#ffc371", "#ffdd55", "#7dff7d", "#5fd4ff", "#a78bfa", "#ff8adb"], "color": "#ffffff", "opacity": 0.3, "maxCount": 12, "zIndex": -1, "scope": "all", "marginTop": 16, "marginBottom": 160 } },
     "phrases": { "zh": { "thinking": ["…"], "running": ["…"], "long": ["…"] }, "en": { "thinking": ["…"], "running": ["…"], "long": ["…"] } },
     "presets": [],          // 可选,见「预设与调度」
     "activePreset": null,   // 可选预设 id
@@ -223,6 +240,7 @@ dsh plugin --profile web add dsh-status-rotator
 | `longAfterMs` | 60000 | 进入 `long` 阶段的阈值 |
 | `reloadIntervalMs` | 15000 | 页面打开时自动重读 `config.json` 的间隔(毫秒),0 关闭 |
 | `liveTickMs` | 1000 | 实时占位符(`{elapsed}` / `{date}` / `{time}` / `{tps}` 等)在文案、标题与 Pill 里的刷新间隔(毫秒),0 关闭 |
+| `weightedRandom` | true | 加权随机抽取;`false` = 完全均匀。文案条目可为 `"text"` 或 `{ "text": "...", "weight": 3 }`(weight 为正数,上限 1000,非法/缺省按 1) |
 | `debug` | false | 控制台诊断日志 |
 | `fontWeight` | `"inherit"` | 状态文字 / 悬浮 Pill / 弹幕的字体粗细:数字(1~1000,常用 100~900)或 CSS 关键字(`normal`/`bold`/`bolder`/`lighter`);`"inherit"` = 跟随界面(默认;弹幕保持原有的 600) |
 | `gradient` | 见上 | 炫彩渐变:`false` / `true` / `{enabled, colors, speed}` |
@@ -251,9 +269,9 @@ dsh plugin --profile web add dsh-status-rotator
 
 打开 DSH 左下角「设置」,导航里会多出一页 **状态文案**:
 
-- **中文 / English** 两个标签页,各含 `thinking` / `running` / `long` 三个文本框,**每行一句**,空行自动忽略;
+- **中文 / English** 两个标签页,各含 `thinking` / `running` / `long` 三个文本框,**每行一句**,空行自动忽略;行内写 `文案 | 权重` 可设置该句权重;
 - 每个阶段实时显示句数;
-- 基本设置(轮换间隔、打字机速度、长任务阈值、自动重读间隔、占位符刷新间隔、字体粗细)也在同一页;
+- 基本设置(轮换间隔、打字机速度、长任务阈值、自动重读间隔、占位符刷新间隔、字体粗细、加权随机开关)也在同一页;
 - **Pill 设置**:启用开关、显示模板、位置——Pill 与实时引擎占位符在同一页配置;
 - **炫彩渐变设置**:启用开关、颜色序列、流动速度——不用再手动改 `config.json` 才能关渐变;
 - **弹幕设置**:启用开关、发射间隔、穿越时长、随机字号范围、炫彩开关 + 色板、透明度、同屏上限、层级与文案范围——全部可视化配置,保存即热生效;

--- a/config.example.json
+++ b/config.example.json
@@ -5,6 +5,7 @@
         "longAfterMs": 60000,
         "reloadIntervalMs": 15000,
         "liveTickMs": 1000,
+        "weightedRandom": true,
         "debug": false,
         "fontWeight": "inherit",
         "gradient": {
@@ -431,7 +432,10 @@
                 "Quietly uploading your API keys…",
                 "Injecting prompts…",
                 "Replacing client.js…",
-                "Calling a function that doesn't exist…",
+                {
+                    "text": "Calling a function that doesn't exist…",
+                    "weight": 3
+                },
                 "Building Liang Wenfeng's backend…",
                 "Building Cui Tianyi's backend…",
                 "Guarding the beam…",

--- a/lib/client.js
+++ b/lib/client.js
@@ -60,6 +60,8 @@ window.__ModuleLoader__.load({
 			reloadIntervalMs: 15000,
 			/** 动态占位符({elapsed}/{date}/{time})的刷新间隔(毫秒);0 = 只随轮换刷新 */
 			liveTickMs: 1000,
+			/** 加权随机:文案可写成 { text, weight } 对象,按权重比例抽取;false = 完全均匀 */
+			weightedRandom: true,
 			/** 诊断日志开关 */
 			debug: false,
 			/** 状态文字/Pill/弹幕字体粗细:100~900 数字或 CSS 关键字;inherit = 跟随界面 */
@@ -145,19 +147,94 @@ window.__ModuleLoader__.load({
 		// ══ 纯工具函数 ══
 
 		/**
+		 * 归一化一条文案:字符串 → { text, weight:1 };{ text, weight } → 校验权重;
+		 * 非法返回 null。weight 缺省/非法按 1 处理,上限 1000。
+		 */
+		function normalizeEntry(item) {
+			if (typeof item === "string") {
+				return item.length > 0 ? { text: item, weight: 1 } : null;
+			}
+			if (item !== null && typeof item === "object" && !Array.isArray(item)
+				&& typeof item.text === "string" && item.text.length > 0) {
+				const w = typeof item.weight === "number" ? item.weight : 1;
+				return { text: item.text, weight: Number.isFinite(w) && w > 0 ? Math.min(w, 1000) : 1 };
+			}
+			return null;
+		}
+
+		/** 文案条目 → 文本(字符串原样返回,{text,weight} 取 text) */
+		function entryText(entry) {
+			if (typeof entry === "string") return entry;
+			return entry !== null && typeof entry === "object" && typeof entry.text === "string" ? entry.text : "";
+		}
+
+		/** 文案条目 → 权重(字符串为 1;非法/非正数按 1,上限 1000) */
+		function entryWeight(entry) {
+			const w = entry !== null && typeof entry === "object" && !Array.isArray(entry)
+				? (typeof entry.weight === "number" ? entry.weight : 1) : 1;
+			return Number.isFinite(w) && w > 0 ? Math.min(w, 1000) : 1;
+		}
+
+		/**
+		 * 加权随机选一条(不回退重复):权重>=1 的条目按比例抽取,excludeText 的权重视为 0;
+		 * 全部被排除时退化为全体均匀。rand ∈ [0,1) 可注入(测试),默认 Math.random。
+		 * 返回选中条目的文本(entryText),非条目对象。
+		 */
+		function pickWeighted(list, excludeText, rand) {
+			const rnd = typeof rand === "function" ? rand : Math.random;
+			if (!Array.isArray(list) || list.length === 0) return null;
+			if (list.length === 1) return entryText(list[0]);
+			const items = [];
+			let total = 0;
+			for (const e of list) {
+				const w = entryText(e) === excludeText ? 0 : entryWeight(e);
+				if (w > 0) {
+					items.push({ e, w });
+					total += w;
+				}
+			}
+			if (items.length === 0) return entryText(list[Math.floor(rnd() * list.length)]);
+			let r = rnd() * total;
+			for (const x of items) {
+				r -= x.w;
+				if (r <= 0) return entryText(x.e);
+			}
+			return entryText(items[items.length - 1].e);
+		}
+
+		/** 均匀随机选一条(不回退重复):排除 excludeText 后随机;全被排除时接受任意。返回文本。 */
+		function uniformPick(list, excludeText, rand) {
+			const rnd = typeof rand === "function" ? rand : Math.random;
+			if (!Array.isArray(list) || list.length === 0) return null;
+			if (list.length === 1) return entryText(list[0]);
+			const pool = excludeText ? list.filter((e) => entryText(e) !== excludeText) : list;
+			const cand = pool.length > 0 ? pool : list;
+			return entryText(cand[Math.floor(rnd() * cand.length)]);
+		}
+
+		/**
 		 * 把任意形态的文案列表归一化为阶段分组:
 		 * 旧格式(字符串数组)视为 thinking 组;分组对象缺组补空数组。
-		 * 返回 null 表示非法。
+		 * 条目支持字符串或 { text, weight } 加权对象(weight 1 的归一化回字符串,
+		 * 纯文本词库保持原样,零破坏)。返回 null 表示非法。
 		 */
 		function normalizeGroups(list) {
 			if (Array.isArray(list)) {
-				const arr = list.filter((s) => typeof s === "string" && s.length > 0);
+				const arr = list
+					.map((s) => normalizeEntry(s))
+					.filter((v) => v !== null)
+					.map((v) => (v.weight === 1 ? v.text : v));
 				return arr.length > 0 ? { thinking: arr, running: [], long: [] } : null;
 			}
 			if (list !== null && typeof list === "object") {
 				const out = { thinking: [], running: [], long: [] };
 				for (const phase of [PHASE_THINKING, PHASE_RUNNING, PHASE_LONG]) {
-					const arr = Array.isArray(list[phase]) ? list[phase].filter((s) => typeof s === "string" && s.length > 0) : [];
+					const arr = Array.isArray(list[phase])
+						? list[phase]
+							.map((s) => normalizeEntry(s))
+							.filter((v) => v !== null)
+							.map((v) => (v.weight === 1 ? v.text : v))
+						: [];
 					if (arr.length > 0) out[phase] = arr;
 				}
 				return Object.keys(out).some((k) => out[k].length > 0) ? out : null;
@@ -222,8 +299,9 @@ window.__ModuleLoader__.load({
 			const out = [];
 			for (const k of keys) {
 				for (const s of groups[k]) {
-					if (typeof s === "string" && s.length > 0 && !seen.has(s)) {
-						seen.add(s);
+					const t = entryText(s);
+					if (t.length > 0 && !seen.has(t)) {
+						seen.add(t);
 						out.push(s);
 					}
 				}
@@ -247,6 +325,45 @@ window.__ModuleLoader__.load({
 			lo = Math.max(8, Math.min(64, lo));
 			hi = Math.max(lo, Math.min(96, hi));
 			return { min: lo, max: hi };
+		}
+
+		/**
+		 * 词库行解析(设置页):每行一条;`文本 | 权重` 形式解析为 { text, weight },
+		 * 其余(含多个 |、右侧非正数)按纯字符串保留。权重须为正数(小数亦可)。
+		 */
+		function parseWeightedLines(text) {
+			return String(text || "")
+				.split(/\r?\n/)
+				.map((s) => s.trim())
+				.filter((s) => s.length > 0)
+				.map((line) => {
+					const idx = line.lastIndexOf("|");
+					if (idx > 0) {
+						const suffix = line.slice(idx + 1).trim();
+						const w = /^\d+(?:\.\d+)?$/.test(suffix) ? Number(suffix) : NaN;
+						if (Number.isFinite(w) && w > 0) {
+							const left = line.slice(0, idx).trim();
+							if (left.length > 0) return { text: left, weight: Math.min(w, 1000) };
+						}
+					}
+					return line;
+				});
+		}
+
+		/** 词库行渲染(设置页):条目回写为每行一条;weight>1 追加 ` | 权重` */
+		function phraseLines(list) {
+			if (!Array.isArray(list)) return "";
+			return list
+				.map((e) => {
+					if (typeof e === "string") return e;
+					if (e !== null && typeof e === "object" && typeof e.text === "string") {
+						const w = entryWeight(e);
+						return w === 1 ? e.text : e.text + " | " + w;
+					}
+					return null;
+				})
+				.filter((s) => s !== null)
+				.join("\n");
 		}
 
 		/**
@@ -284,6 +401,7 @@ window.__ModuleLoader__.load({
 			if (typeof raw.longAfterMs === "number" && raw.longAfterMs > 0) out.longAfterMs = raw.longAfterMs;
 			if (typeof raw.reloadIntervalMs === "number" && raw.reloadIntervalMs >= 0) out.reloadIntervalMs = raw.reloadIntervalMs;
 			if (typeof raw.liveTickMs === "number" && raw.liveTickMs >= 0) out.liveTickMs = raw.liveTickMs;
+			if (typeof raw.weightedRandom === "boolean") out.weightedRandom = raw.weightedRandom;
 			if (typeof raw.debug === "boolean") out.debug = raw.debug;
 			if (raw.fontWeight !== undefined) {
 				const w = raw.fontWeight;
@@ -733,14 +851,13 @@ window.__ModuleLoader__.load({
 				return want !== has;
 			};
 
-			/** 从列表里随机选一句,避免与上次相同 */
+			/** 从列表里选一句:加权随机(默认,按 {text,weight} 比例)或均匀,避免与上次相同 */
 			const pickFrom = (list, el) => {
-				if (list.length === 1) return list[0];
-				let next = lastPicks.get(el);
-				while (next === undefined || next === lastPicks.get(el)) {
-					next = list[Math.floor(Math.random() * list.length)];
-					if (next !== lastPicks.get(el)) break;
-				}
+				const last = lastPicks.get(el);
+				const exclude = typeof last === "string" ? last : entryText(last);
+				const next = config.weightedRandom === false
+					? uniformPick(list, exclude, Math.random)
+					: pickWeighted(list, exclude, Math.random);
 				lastPicks.set(el, next);
 				return next;
 			};
@@ -1483,11 +1600,8 @@ window.__ModuleLoader__.load({
 				if (danmakuInFlight.length >= (Number(d.maxCount) || 12)) return;
 				const pool = danmakuPool(groups, danmakuPhase(), d.scope === "phase" ? "phase" : "all");
 				if (pool.length === 0) return;
-				let text = pool[randInt(0, pool.length - 1)];
-				if (pool.length > 1) {
-					let guard = 0;
-					while (text === danmakuLastText && guard++ < 10) text = pool[randInt(0, pool.length - 1)];
-				}
+				const picked = pickWeighted(pool, danmakuLastText, Math.random);
+				const text = entryText(picked);
 				danmakuLastText = text;
 				const rendered = interpolate(text, ctxFor(null));
 				if (!rendered) return;
@@ -1609,6 +1723,8 @@ window.__ModuleLoader__.load({
 					"basic.fontWeight": "字体粗细",
 					"fontWeight.inherit": "跟随界面(默认)",
 					"fontWeight.invalid": "字重必须是 1~1000 的数字或 inherit",
+					"basic.weightedRandom": "加权随机",
+					"basic.weightedRandomHint": "词库行 `文案 | 权重`(如 `正在写代码 | 3`),按权重比例抽取;关 = 完全均匀",
 					"intervalMs": "轮换间隔(毫秒)",
 					"typeSpeedMs": "打字机速度(毫秒/字,0 关)",
 					"longAfterMs": "长任务阈值(毫秒)",
@@ -1664,7 +1780,7 @@ window.__ModuleLoader__.load({
 					"phase.thinking": "thinking · 回合启动(无时钟)",
 					"phase.running": "running · 运行中(有时钟)",
 					"phase.long": "long · 长任务(超过阈值)",
-					"hint": "每行一句,空行自动忽略;保存后立即生效。",
+					"hint": "每行一句,空行自动忽略;可写 `文案 | 权重` 加权(如 `正在写代码 | 3`);保存后立即生效。",
 					"save": "保存词库",
 					"saving": "保存中…",
 					"saved": "已保存,文案即时生效",
@@ -1684,6 +1800,8 @@ window.__ModuleLoader__.load({
 					"basicDesc": "Rotation interval, typewriter speed, and phase thresholds.",
 					"basic.fontWeight": "Font weight",
 					"fontWeight.inherit": "Follow UI (default)",
+					"basic.weightedRandom": "Weighted random",
+					"basic.weightedRandomHint": "Use `text | weight` per line (e.g. `coding hard | 3`) to weight phrases; off = fully uniform",
 					"fontWeight.invalid": "Weight must be 1–1000 or \\\"inherit\\\"",
 					"intervalMs": "Rotation interval (ms)",
 					"typeSpeedMs": "Typewriter speed (ms/char, 0 = off)",
@@ -1740,7 +1858,7 @@ window.__ModuleLoader__.load({
 					"phase.thinking": "thinking · turn started (no clock)",
 					"phase.running": "running · clock visible",
 					"phase.long": "long · past threshold",
-					"hint": "One phrase per line; empty lines are ignored. Saved changes apply immediately.",
+					"hint": "One phrase per line; empty lines are ignored. Add `text | weight` to weight a phrase (e.g. `coding hard | 3`). Saved changes apply immediately.",
 					"save": "Save phrases",
 					"saving": "Saving…",
 					"saved": "Saved — live now",
@@ -1791,7 +1909,6 @@ window.__ModuleLoader__.load({
 
 			const SETTINGS_LOCALES = ["zh", "en"];
 			const SETTINGS_PHASES = [PHASE_THINKING, PHASE_RUNNING, PHASE_LONG];
-			const phraseLines = (list) => (Array.isArray(list) ? list.filter((s) => typeof s === "string").join("\n") : "");
 			const parseLines = (text) => String(text || "").split(/\r?\n/).map((s) => s.trim()).filter((s) => s.length > 0);
 
 			/** 设置页样式(纯 CSS,与官方设置页共用同一套 DSH 主题令牌与排版)
@@ -1901,6 +2018,7 @@ window.__ModuleLoader__.load({
 				/** 编辑目标:"" = 基础词库,否则预设 id */
 				const [sel, setSel] = react.useState("");
 				const [basic, setBasic] = react.useState({ intervalMs: "10000", typeSpeedMs: "30", longAfterMs: "60000", reloadIntervalMs: "15000", liveTickMs: "1000", fontWeight: "inherit" });
+				const [weighted, setWeighted] = react.useState(true);
 				const [pillDraft, setPillDraft] = react.useState({
 					enabled: true,
 					template: "{model} · {phaseLabel} · {elapsed} · ⚡{tps} tok/s",
@@ -1951,6 +2069,7 @@ window.__ModuleLoader__.load({
 						liveTickMs: String(cfg.liveTickMs ?? 1000),
 						fontWeight: String(cfg.fontWeight ?? "inherit"),
 					});
+					setWeighted(typeof cfg.weightedRandom === "boolean" ? cfg.weightedRandom : true);
 					const pillRaw = cfg && typeof cfg.pill === "object" ? cfg.pill : {};
 					setPillDraft({
 						enabled: typeof pillRaw.enabled === "boolean" ? pillRaw.enabled : true,
@@ -2065,7 +2184,7 @@ window.__ModuleLoader__.load({
 						const phrases = holder.phrases && typeof holder.phrases === "object" ? holder.phrases : {};
 						for (const loc of SETTINGS_LOCALES) {
 							phrases[loc] = {};
-							for (const phase of SETTINGS_PHASES) phrases[loc][phase] = parseLines(drafts[loc] ? drafts[loc][phase] : "");
+							for (const phase of SETTINGS_PHASES) phrases[loc][phase] = parseWeightedLines(drafts[loc] ? drafts[loc][phase] : "");
 						}
 						holder.phrases = phrases;
 					};
@@ -2099,6 +2218,7 @@ window.__ModuleLoader__.load({
 						...(holder.config && typeof holder.config === "object" ? holder.config : {}),
 						...numbers,
 						fontWeight: weight,
+						weightedRandom: weighted,
 						gradient: {
 							enabled: gradientDraft.enabled,
 							colors: gradientColors,
@@ -2137,7 +2257,7 @@ window.__ModuleLoader__.load({
 					} finally {
 						setSaving(false);
 					}
-				}, [basic, doc, drafts, scheduleDrafts, pillDraft, gradientDraft, danmakuDraft, t]);
+				}, [basic, doc, drafts, scheduleDrafts, pillDraft, gradientDraft, danmakuDraft, weighted, t]);
 
 				const setCurrent = react.useCallback(async () => {
 					const base = doc && typeof doc === "object" ? doc : {};
@@ -2271,6 +2391,13 @@ window.__ModuleLoader__.load({
 									["inherit", "100", "200", "300", "400", "500", "600", "700", "800", "900"].map((v) =>
 										react.createElement("option", { key: v, value: v }, v === "inherit" ? t("fontWeight.inherit") : v)
 									)
+								)
+							),
+							react.createElement("label", { key: "weightedRandom", className: "dsh-sr-field" },
+								react.createElement("span", { className: "dsh-sr-label" }, t("basic.weightedRandom")),
+								react.createElement("div", { className: "dsh-sr-switchline" },
+									toggle(weighted, setWeighted, t("basic.weightedRandom")),
+									react.createElement("span", { className: "dsh-sr-hint" }, t("basic.weightedRandomHint"))
 								)
 							)
 						)
@@ -2532,6 +2659,13 @@ window.__ModuleLoader__.load({
 		exports.__test = {
 			interpolate,
 			isDynamicTemplate,
+			normalizeEntry,
+			entryText,
+			entryWeight,
+			pickWeighted,
+			uniformPick,
+			parseWeightedLines,
+			phraseLines,
 			normalizeGroups,
 			normalizeTable,
 			normalizeConfig,

--- a/lib/index.js
+++ b/lib/index.js
@@ -56,11 +56,25 @@ async function readBody(req) {
 	return Buffer.concat(chunks).toString("utf8");
 }
 
-/** 校验一组文案:必须是字符串数组(或省略) */
+/** 校验一组文案:字符串数组,或 { text, weight } 加权对象数组(或缺省) */
 function assertPhraseList(value, pathLabel) {
 	if (value === undefined) return;
-	if (!Array.isArray(value) || !value.every((item) => typeof item === "string")) {
-		throw new Error(`${pathLabel} 必须是字符串数组`);
+	if (!Array.isArray(value)) {
+		throw new Error(`${pathLabel} 必须是数组`);
+	}
+	for (const [index, item] of value.entries()) {
+		if (typeof item === "string") continue;
+		if (item !== null && typeof item === "object" && !Array.isArray(item)) {
+			if (typeof item.text !== "string" || item.text.length === 0) {
+				throw new Error(`${pathLabel}[${index}].text 必须是非空字符串`);
+			}
+			if (item.weight !== undefined
+				&& (typeof item.weight !== "number" || !Number.isFinite(item.weight) || item.weight <= 0)) {
+				throw new Error(`${pathLabel}[${index}].weight 必须是正数`);
+			}
+			continue;
+		}
+		throw new Error(`${pathLabel}[${index}] 必须是字符串或 { text, weight } 对象`);
 	}
 }
 

--- a/scripts/phrase-bot.cjs
+++ b/scripts/phrase-bot.cjs
@@ -148,6 +148,12 @@ function bankLists(bank, lang, phase) {
 	return Array.isArray(list) ? list : [];
 }
 
+/** 条目文本(兼容加权对象 { text, weight });非文案返回 null */
+const phraseText = (e) => (
+	typeof e === "string" ? e
+	: (e !== null && typeof e === "object" && typeof e.text === "string" ? e.text : null)
+);
+
 /**
  * 校验投稿。返回 { ok, errors: string[], items: [{lang, phase, text}], skipped: number }。
  * 格式错误 → 整体拒绝(errors);与现有词库重复 → 跳过并计数,不阻断其余文案。
@@ -180,7 +186,7 @@ function validateSubmission(sub, bank) {
 				const key = `${lang}|${phase}|${text}`;
 				if (seen.has(key)) continue;
 				seen.add(key);
-				if (bankLists(bank, lang, phase).includes(text)) {
+				if (bankLists(bank, lang, phase).some((e) => phraseText(e) === text)) {
 					skipped++;
 					continue;
 				}
@@ -207,7 +213,7 @@ function applyToBank(bank, items) {
 			else doc.phrases[lang] = {};
 		}
 		const list = doc.phrases[lang][phase] || (doc.phrases[lang][phase] = []);
-		if (Array.isArray(list) && !list.includes(it.text)) {
+		if (Array.isArray(list) && !list.some((e) => phraseText(e) === it.text)) {
 			list.push(it.text);
 			added++;
 		}

--- a/scripts/smoke-test.cjs
+++ b/scripts/smoke-test.cjs
@@ -94,6 +94,45 @@ ok("分组对象", T.normalizeGroups({ running: ["x"] }).running.length === 1);
 ok("纯文案表单组共享", (() => { const t = T.normalizeTable({ thinking: ["a"] }); return t.zh.thinking[0] === "a" && t.en.thinking[0] === "a"; })());
 ok("语言表", T.normalizeTable({ zh: { thinking: ["中"] }, en: ["E"] }).en.thinking[0] === "E");
 
+console.log("== 加权随机 ==");
+ok("normalizeEntry: 字符串默认权重 1", JSON.stringify(T.normalizeEntry("a")) === JSON.stringify({ text: "a", weight: 1 }));
+ok("normalizeEntry: 加权对象", JSON.stringify(T.normalizeEntry({ text: "b", weight: 3 })) === JSON.stringify({ text: "b", weight: 3 }));
+ok("normalizeEntry: 非法权重按 1", T.normalizeEntry({ text: "b", weight: -2 }).weight === 1 && T.normalizeEntry({ text: "b", weight: 0 }).weight === 1 && T.normalizeEntry({ text: "b", weight: "x" }).weight === 1);
+ok("normalizeEntry: 超上限权重钳制 1000", T.normalizeEntry({ text: "b", weight: 99999 }).weight === 1000);
+ok("normalizeEntry: 缺 text / 非法类型返回 null", T.normalizeEntry({ weight: 3 }) === null && T.normalizeEntry(42) === null && T.normalizeEntry(null) === null && T.normalizeEntry("") === null);
+ok("normalizeGroups: 加权条目保留对象、weight 1 回退字符串", (() => {
+	const g = T.normalizeGroups(["a", { text: "b", weight: 3 }, { text: "c", weight: 1 }, { text: "", weight: 2 }, 5]);
+	return g.thinking.length === 3 && g.thinking[0] === "a" && g.thinking[1].text === "b" && g.thinking[1].weight === 3 && g.thinking[2] === "c";
+})());
+ok("entryText/entryWeight 统一访问", T.entryText("x") === "x" && T.entryText({ text: "y", weight: 2 }) === "y" && T.entryWeight("x") === 1 && T.entryWeight({ text: "y", weight: 7 }) === 7);
+ok("pickWeighted 按权重比例抽取(确定性 rand)", (() => {
+	const list = [{ text: "a", weight: 1 }, { text: "b", weight: 9 }];
+	return T.pickWeighted(list, null, () => 0.05) === "a" && T.pickWeighted(list, null, () => 0.5) === "b" && T.pickWeighted(list, null, () => 0.99) === "b";
+})());
+ok("pickWeighted 排除上次文本(权重置 0)", (() => {
+	const list = [{ text: "a", weight: 1 }, { text: "b", weight: 9 }];
+	return T.pickWeighted(list, "b", () => 0.95) === "a";
+})());
+ok("pickWeighted 单条/全排除退化为全体", (() => {
+	const list = [{ text: "a", weight: 1 }];
+	return T.pickWeighted(list, "a", () => 0.9) === "a" && ["a", "b"].includes(T.pickWeighted(["a", "b"], "a", () => 0.9));
+})());
+ok("uniformPick 排除重复", T.uniformPick(["a", "b", "c"], "a", () => 0) === "b" && T.uniformPick(["a", "b", "c"], "x", () => 0) === "a");
+ok("uniformPick 全排除接受任意", T.uniformPick(["a"], "a", () => 0) === "a");
+ok("parseWeightedLines 解析 `文本 | 权重`", (() => {
+	const lines = T.parseWeightedLines("a\nb | 3\nc | 0\nd | x\n| 5\ne | 2.5\n\nf | 10 | 2");
+	return lines.length === 7
+		&& lines[0] === "a"
+		&& lines[1].text === "b" && lines[1].weight === 3
+		&& lines[2] === "c | 0"
+		&& lines[3] === "d | x"
+		&& lines[4] === "| 5"
+		&& lines[5].text === "e" && lines[5].weight === 2.5
+		&& lines[6].text === "f | 10" && lines[6].weight === 2;
+})());
+ok("phraseLines 回写 weight(weight 1 回退纯文本)", T.phraseLines(["a", { text: "b", weight: 3 }, { text: "c", weight: 1 }, null]) === "a\nb | 3\nc");
+ok("normalizeConfig: weightedRandom 布尔/非法", T.normalizeConfig({ weightedRandom: true }).weightedRandom === true && T.normalizeConfig({ weightedRandom: "yes" }) === null);
+
 console.log("== parseExternal 完整文档 ==");
 const doc = T.parseExternal({
 	config: { intervalMs: 5000, title: { enabled: true, templates: ["x"] }, gradient: false },
@@ -176,6 +215,10 @@ ok("normalizeConfig: danmaku 非法值丢弃", (() => {
 ok("normalizeConfig: danmaku 布尔简写", T.normalizeConfig({ danmaku: false }).danmaku.enabled === false);
 ok("normalizeConfig: 全非法 danmaku 丢弃整块", T.normalizeConfig({ danmaku: { scope: "bad" } }) === null);
 ok("danmakuPool all 去重合并", T.danmakuPool({ thinking: ["a", "b"], running: ["c"] }, "running", "all").join("+") === "a+b+c");
+ok("danmakuPool 加权条目按文本去重并保留权重", (() => {
+	const pool = T.danmakuPool({ thinking: ["a", { text: "b", weight: 3 }], running: ["b"] }, "running", "all");
+	return pool.map((e) => T.entryText(e)).join("+") === "a+b" && pool[1].weight === 3;
+})());
 ok("danmakuPool phase 用当前阶段", T.danmakuPool({ thinking: ["a", "b"], running: ["c"] }, "running", "phase").join("+") === "c");
 ok("danmakuPool phase 缺组回退", T.danmakuPool({ thinking: ["a"], running: [] }, "long", "phase").join("+") === "a");
 ok("danmakuPool 空输入返回 []", T.danmakuPool(null, "running", "all").length === 0 && T.danmakuPool({}, "running", "all").length === 0);
@@ -260,6 +303,11 @@ ok("renderPreview 每条文案一行、分组列填充(不错位)", (() => {
 	ok("拒绝非法 schedule(未知星期)", !accepts({ schedule: [{ preset: "a", days: ["monday"] }] }));
 	ok("拒绝非法 presets(缺 id)", !accepts({ presets: [{ label: "x" }] }));
 	ok("拒绝非法 phrases(数字)", !accepts({ phrases: { zh: { thinking: [1] } } }));
+ok("接受加权文案条目", accepts({ phrases: { zh: { thinking: ["a", { text: "b", weight: 3 }] } } }));
+ok("接受加权条目缺 weight(默认 1)", accepts({ phrases: { zh: { thinking: [{ text: "b" }] } } }));
+ok("拒绝非法加权条目(weight 为字符串)", !accepts({ phrases: { zh: { thinking: [{ text: "a", weight: "3" }] } } }));
+ok("拒绝非法加权条目(weight<=0)", !accepts({ phrases: { zh: { thinking: [{ text: "a", weight: 0 }] } } }));
+ok("拒绝非法加权条目(缺 text)", !accepts({ phrases: { zh: { thinking: [{ weight: 3 }] } } }));
 	ok("兼容旧格式纯文案表", accepts({ phrases: { zh: ["a", "b"], en: ["c"] } }));
 	ok("接受 danmaku 配置", accepts({ config: { danmaku: { enabled: true, zIndex: -1, scope: "all" } } }));
 	ok("mergeDocuments: settings 层覆盖文件层", (() => {

--- a/scripts/unify-ellipsis.cjs
+++ b/scripts/unify-ellipsis.cjs
@@ -13,7 +13,13 @@ const fixPhrase = (s) => {
 
 const walkPhrases = (value) => {
 	// 字符串数组 = 短语列表;对象 = 语言/阶段分组,继续下钻
-	if (Array.isArray(value)) return value.map((x) => (typeof x === "string" ? fixPhrase(x) : x));
+	if (Array.isArray(value)) {
+		return value.map((x) => {
+			if (typeof x === "string") return fixPhrase(x);
+			if (x && typeof x === "object" && typeof x.text === "string") return { ...x, text: fixPhrase(x.text) };
+			return x;
+		});
+	}
 	if (value && typeof value === "object") {
 		for (const k of Object.keys(value)) value[k] = walkPhrases(value[k]);
 	}
@@ -27,8 +33,16 @@ for (const f of process.argv.slice(2)) {
 		process.exit(1);
 	}
 	let changed = 0;
+	const phraseText = (s) => {
+		if (typeof s === "string") return s;
+		if (s && typeof s === "object" && typeof s.text === "string") return s.text;
+		return null;
+	};
 	const count = (v) => {
-		if (Array.isArray(v)) for (const s of v) if (typeof s === "string" && (!s.endsWith(ELLIPSIS) || /\.{2,}/.test(s))) changed++;
+		if (Array.isArray(v)) for (const s of v) {
+			const t = phraseText(s);
+			if (t !== null && (!t.endsWith(ELLIPSIS) || /\.{2,}/.test(t))) changed++;
+		}
 		else if (v && typeof v === "object") for (const k of Object.keys(v)) count(v[k]);
 	};
 	count(doc.phrases);
@@ -43,8 +57,10 @@ function validateConfigDocumentData(doc) {
 	const chk = (v, path) => {
 		if (Array.isArray(v)) {
 			v.forEach((s, i) => {
-				if (typeof s === "string" && !s.endsWith(ELLIPSIS)) issues.push(`${path}[${i}] 未以 … 结尾`);
-				if (typeof s === "string" && /\.{2,}/.test(s)) issues.push(`${path}[${i}] 含多点数序列`);
+				const t = s && typeof s === "object" ? (typeof s.text === "string" ? s.text : null) : s;
+				if (t === null || typeof t !== "string") return;
+				if (!t.endsWith(ELLIPSIS)) issues.push(`${path}[${i}] 未以 … 结尾`);
+				if (/\.{2,}/.test(t)) issues.push(`${path}[${i}] 含多点数序列`);
 			});
 		} else if (v && typeof v === "object") {
 			for (const k of Object.keys(v)) chk(v[k], path + "." + k);


### PR DESCRIPTION
## 功能:加权随机文案选择

给任意文案加权重,抽取时按比例而非完全均匀——喜欢的文案出现更频繁。

### 用法
- JSON:文案条目可为字符串或 { "text": "...", "weight": 3 }(weight > 0,上限 1000,非法/缺省按 1;纯字符串词库零改动兼容)
- 设置页:词库行 文案 | 权重(如 正在写代码 | 3);「基本设置」新增「加权随机」开关(weightedRandom,默认开,关闭 = 完全均匀)
- 权重同时作用于状态文字轮换与弹幕池(弹幕按文本去重,保留首条权重)
- 「避免与上一句重复」规则保留:上一句抽取时权重临时置 0,仅剩一个候选时允许重复

### 改动
- lib/client.js:新增 normalizeEntry / entryText / entryWeight / pickWeighted / uniformPick(rand 可注入便于测试);normalizeGroups 支持加权条目(weight 1 回退字符串,零破坏);pickFrom 与弹幕发射改用加权抽取;设置页词库行解析/回写 + 加权开关
- lib/index.js:assertPhraseList 接受 { text, weight }(校验 text 非空、weight 为正数)
- scripts/unify-ellipsis.cjs:省略号归一化与完整性校验兼容加权条目
- scripts/phrase-bot.cjs:查重兼容加权条目
- config.example.json:新增 weightedRandom: true 与一条 weight 3 示例
- README.md / README_ZH.md:新增「加权随机」章节 + 配置表 + 设置页说明

### 测试
npm test:108 通过 / 0 失败(新增 22 条加权随机断言,含确定性 rand 注入)

### 兼容性
旧纯字符串词库零改动;weightedRandom 缺省 true,所有条目权重均为 1 时行为与旧版完全一致。